### PR TITLE
refactor: remove unnecessary toUppercase function

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,6 +1,5 @@
 const { fetchBooks } = require("../api");
 const { sortByID } = require("../utils/sortByID");
-const { toUppercase } = require("../utils/toUppercase");
 const { modifySubjects } = require("../utils/modifySubjects");
 
 describe("sortByID", () => {
@@ -13,27 +12,6 @@ describe("sortByID", () => {
         ascending: true,
       });
     });
-  });
-});
-
-describe("toUppercase", () => {
-  test("returns string as uppercase", () => {
-    const input = "hello";
-    const actual = toUppercase(input);
-    const expected = "HELLO";
-    expect(actual).toBe(expected);
-  });
-  test("returns string as uppercase if mixed with numbers", () => {
-    const input = "thisISaTest100";
-    const actual = toUppercase(input);
-    const expected = "THISISATEST100";
-    expect(actual).toBe(expected);
-  });
-  test("returns string as uppercase if mixed with symbols", () => {
-    const input = "this -- is a / test";
-    const actual = toUppercase(input);
-    const expected = "THIS -- IS A / TEST";
-    expect(actual).toBe(expected);
   });
 });
 

--- a/utils/toUppercase.js
+++ b/utils/toUppercase.js
@@ -1,6 +1,0 @@
-const toUppercase = (string) => {
-  updatedString = string;
-  return updatedString.toUpperCase();
-};
-
-module.exports = { toUppercase };


### PR DESCRIPTION
- removed unnecessary toUppercase function as .toUpperCase() is now used directly in modifySubjects